### PR TITLE
Add GitHub Enterprise support

### DIFF
--- a/MonitorLizard/Models/DemoData.swift
+++ b/MonitorLizard/Models/DemoData.swift
@@ -27,7 +27,8 @@ enum DemoData {
                 StatusCheck(id: "1", name: "CI Tests", status: .success, detailsUrl: "https://github.com/example/check/1"),
                 StatusCheck(id: "2", name: "Lint", status: .success, detailsUrl: "https://github.com/example/check/2")
             ],
-            reviewDecision: .approved
+            reviewDecision: .approved,
+            host: "github.com"
         ),
 
         // 2. PENDING - Reviewing PR (with review required)
@@ -53,7 +54,8 @@ enum DemoData {
                 StatusCheck(id: "1", name: "CI Tests", status: .pending, detailsUrl: "https://github.com/example/check/1"),
                 StatusCheck(id: "2", name: "Lint", status: .success, detailsUrl: "https://github.com/example/check/2")
             ],
-            reviewDecision: .reviewRequired
+            reviewDecision: .reviewRequired,
+            host: "github.com"
         ),
 
         // AUTHORED PRs (6 total)
@@ -82,7 +84,8 @@ enum DemoData {
                 StatusCheck(id: "2", name: "Unit Tests", status: .success, detailsUrl: "https://github.com/example/check/2"),
                 StatusCheck(id: "3", name: "Integration Tests", status: .success, detailsUrl: "https://github.com/example/check/3")
             ],
-            reviewDecision: .changesRequested
+            reviewDecision: .changesRequested,
+            host: "github.com"
         ),
 
         // 4. FAILURE - Authored PR
@@ -110,7 +113,8 @@ enum DemoData {
                 StatusCheck(id: "2", name: "Lint", status: .failure, detailsUrl: "https://github.com/example/check/2"),
                 StatusCheck(id: "3", name: "Security Scan", status: .success, detailsUrl: "https://github.com/example/check/3")
             ],
-            reviewDecision: nil
+            reviewDecision: nil,
+            host: "github.com"
         ),
 
         // 5. PENDING - Authored PR
@@ -134,7 +138,8 @@ enum DemoData {
                 StatusCheck(id: "1", name: "Build", status: .pending, detailsUrl: "https://github.com/example/check/1"),
                 StatusCheck(id: "2", name: "Tests", status: .pending, detailsUrl: "https://github.com/example/check/2")
             ],
-            reviewDecision: nil
+            reviewDecision: nil,
+            host: "github.com"
         ),
 
         // 6. CONFLICT - Authored PR
@@ -159,7 +164,8 @@ enum DemoData {
             statusChecks: [
                 StatusCheck(id: "1", name: "Merge Conflict Check", status: .failure, detailsUrl: "https://github.com/example/check/1")
             ],
-            reviewDecision: nil
+            reviewDecision: nil,
+            host: "github.com"
         ),
 
         // 7. INACTIVE - Authored PR (Draft)
@@ -185,7 +191,8 @@ enum DemoData {
             statusChecks: [
                 StatusCheck(id: "1", name: "Draft PR Check", status: .skipped, detailsUrl: "https://github.com/example/check/1")
             ],
-            reviewDecision: nil
+            reviewDecision: nil,
+            host: "github.com"
         ),
 
         // 8. PENDING - Authored PR (Draft)
@@ -210,7 +217,8 @@ enum DemoData {
             statusChecks: [
                 StatusCheck(id: "1", name: "Code Quality", status: .pending, detailsUrl: "https://github.com/example/check/1")
             ],
-            reviewDecision: nil
+            reviewDecision: nil,
+            host: "github.com"
         )
     ]
 }

--- a/MonitorLizard/Models/PullRequest.swift
+++ b/MonitorLizard/Models/PullRequest.swift
@@ -51,6 +51,7 @@ struct PullRequest: Identifiable, Hashable {
     let isDraft: Bool
     let statusChecks: [StatusCheck]
     var reviewDecision: ReviewDecision?
+    let host: String  // GitHub host (e.g. "github.com" or enterprise hostname)
 
     var id: String {
         "\(repository.nameWithOwner)#\(number)"

--- a/MonitorLizard/Services/GitHubService.swift
+++ b/MonitorLizard/Services/GitHubService.swift
@@ -77,55 +77,66 @@ class GitHubService: ObservableObject {
             return PRFetchResult(pullRequests: DemoData.samplePullRequests, isPartial: false)
         }
 
-        // Fetch both authored and review PRs in parallel with independent error handling
-        // This allows one type to fail (e.g., no review PRs) without affecting the other
-        async let authoredTask = fetchAuthoredPRsSafely(enableInactiveDetection: enableInactiveDetection, inactiveThresholdDays: inactiveThresholdDays)
-        async let reviewTask = fetchReviewPRsSafely(enableInactiveDetection: enableInactiveDetection, inactiveThresholdDays: inactiveThresholdDays)
+        // Detect all authenticated GitHub hosts (github.com + any enterprise instances)
+        let hosts = try await shellExecutor.getAuthenticatedHosts()
 
-        let authoredResult = await authoredTask
-        let reviewResult = await reviewTask
+        var allAuthored: [PullRequest] = []
+        var allReview: [PullRequest] = []
+        var anyPartial = false
+        var allFailed = true
 
-        // If both fetches failed, throw an error instead of returning empty array
-        // This distinguishes between "no PRs found" (success with empty array) and
-        // "couldn't fetch PRs" (network/auth error that should be shown to user)
-        if case .failure(let authoredError) = authoredResult,
-           case .failure(let reviewError) = reviewResult {
-            print("Both PR fetches failed - authored: \(authoredError), review: \(reviewError)")
-            // Throw the authored error as it's likely the same root cause
-            throw authoredError
+        for host in hosts {
+            // Fetch both authored and review PRs in parallel with independent error handling
+            async let authoredTask = fetchAuthoredPRsSafely(enableInactiveDetection: enableInactiveDetection, inactiveThresholdDays: inactiveThresholdDays, host: host)
+            async let reviewTask = fetchReviewPRsSafely(enableInactiveDetection: enableInactiveDetection, inactiveThresholdDays: inactiveThresholdDays, host: host)
+
+            let authoredResult = await authoredTask
+            let reviewResult = await reviewTask
+
+            if let authored = authoredResult.success {
+                allAuthored.append(contentsOf: authored)
+                allFailed = false
+            } else {
+                anyPartial = true
+            }
+
+            if let review = reviewResult.success {
+                allReview.append(contentsOf: review)
+                allFailed = false
+            } else {
+                anyPartial = true
+            }
         }
 
-        // Extract successful results (empty arrays for failures)
-        let authored = authoredResult.success ?? []
-        let review = reviewResult.success ?? []
+        // If all fetches across all hosts failed, throw an error
+        if allFailed {
+            throw GitHubError.networkError
+        }
 
-        // Mark as partial if either fetch failed (results may be incomplete)
-        let isPartial = authoredResult.success == nil || reviewResult.success == nil
-
-        return PRFetchResult(pullRequests: review + authored, isPartial: isPartial)  // Review PRs first to prioritize unblocking teammates
+        return PRFetchResult(pullRequests: allReview + allAuthored, isPartial: anyPartial)  // Review PRs first to prioritize unblocking teammates
     }
 
-    private func fetchAuthoredPRsSafely(enableInactiveDetection: Bool, inactiveThresholdDays: Int) async -> Result<[PullRequest], Error> {
+    private func fetchAuthoredPRsSafely(enableInactiveDetection: Bool, inactiveThresholdDays: Int, host: String) async -> Result<[PullRequest], Error> {
         do {
-            let prs = try await fetchAuthoredPRs(enableInactiveDetection: enableInactiveDetection, inactiveThresholdDays: inactiveThresholdDays)
+            let prs = try await fetchAuthoredPRs(enableInactiveDetection: enableInactiveDetection, inactiveThresholdDays: inactiveThresholdDays, host: host)
             return .success(prs)
         } catch {
-            print("Error fetching authored PRs: \(error)")
+            print("Error fetching authored PRs from \(host): \(error)")
             return .failure(error)
         }
     }
 
-    private func fetchReviewPRsSafely(enableInactiveDetection: Bool, inactiveThresholdDays: Int) async -> Result<[PullRequest], Error> {
+    private func fetchReviewPRsSafely(enableInactiveDetection: Bool, inactiveThresholdDays: Int, host: String) async -> Result<[PullRequest], Error> {
         do {
-            let prs = try await fetchReviewPRs(enableInactiveDetection: enableInactiveDetection, inactiveThresholdDays: inactiveThresholdDays)
+            let prs = try await fetchReviewPRs(enableInactiveDetection: enableInactiveDetection, inactiveThresholdDays: inactiveThresholdDays, host: host)
             return .success(prs)
         } catch {
-            print("Error fetching review PRs: \(error)")
+            print("Error fetching review PRs from \(host): \(error)")
             return .failure(error)
         }
     }
 
-    private func fetchAuthoredPRs(enableInactiveDetection: Bool, inactiveThresholdDays: Int) async throws -> [PullRequest] {
+    private func fetchAuthoredPRs(enableInactiveDetection: Bool, inactiveThresholdDays: Int, host: String) async throws -> [PullRequest] {
         // Fetch all open PRs authored by the current user, excluding archived repositories
         let json = try await shellExecutor.execute(
             command: "gh",
@@ -136,7 +147,8 @@ class GitHubService: ObservableObject {
                 "--archived=false",
                 "--json", "number,title,repository,url,author,updatedAt,labels,isDraft",
                 "--limit", "100"
-            ]
+            ],
+            host: host
         )
 
         // Parse the JSON response
@@ -190,7 +202,8 @@ class GitHubService: ObservableObject {
                 number: result.number,
                 updatedAt: updatedAt,
                 enableInactiveDetection: enableInactiveDetection,
-                inactiveThresholdDays: inactiveThresholdDays
+                inactiveThresholdDays: inactiveThresholdDays,
+                host: host
             )
 
             let pr = PullRequest(
@@ -212,7 +225,8 @@ class GitHubService: ObservableObject {
                 type: .authored,
                 isDraft: result.isDraft,
                 statusChecks: statusInfo.statusChecks,
-                reviewDecision: statusInfo.reviewDecision
+                reviewDecision: statusInfo.reviewDecision,
+                host: host
             )
 
             pullRequests.append(pr)
@@ -221,7 +235,7 @@ class GitHubService: ObservableObject {
         return pullRequests
     }
 
-    private func fetchReviewPRs(enableInactiveDetection: Bool, inactiveThresholdDays: Int) async throws -> [PullRequest] {
+    private func fetchReviewPRs(enableInactiveDetection: Bool, inactiveThresholdDays: Int, host: String) async throws -> [PullRequest] {
         // Fetch all open PRs where the current user is a requested reviewer, excluding archived repositories
         let json = try await shellExecutor.execute(
             command: "gh",
@@ -232,7 +246,8 @@ class GitHubService: ObservableObject {
                 "--archived=false",
                 "--json", "number,title,repository,url,author,updatedAt,labels,isDraft",
                 "--limit", "100"
-            ]
+            ],
+            host: host
         )
 
         // Parse the JSON response
@@ -286,7 +301,8 @@ class GitHubService: ObservableObject {
                 number: result.number,
                 updatedAt: updatedAt,
                 enableInactiveDetection: enableInactiveDetection,
-                inactiveThresholdDays: inactiveThresholdDays
+                inactiveThresholdDays: inactiveThresholdDays,
+                host: host
             )
 
             let pr = PullRequest(
@@ -308,7 +324,8 @@ class GitHubService: ObservableObject {
                 type: .reviewing,
                 isDraft: result.isDraft,
                 statusChecks: statusInfo.statusChecks,
-                reviewDecision: statusInfo.reviewDecision
+                reviewDecision: statusInfo.reviewDecision,
+                host: host
             )
 
             pullRequests.append(pr)
@@ -317,14 +334,15 @@ class GitHubService: ObservableObject {
         return pullRequests
     }
 
-    func fetchPRStatus(owner: String, repo: String, number: Int, updatedAt: Date, enableInactiveDetection: Bool, inactiveThresholdDays: Int) async throws -> (status: BuildStatus, headRefName: String, statusChecks: [StatusCheck], reviewDecision: ReviewDecision?) {
+    func fetchPRStatus(owner: String, repo: String, number: Int, updatedAt: Date, enableInactiveDetection: Bool, inactiveThresholdDays: Int, host: String = "github.com") async throws -> (status: BuildStatus, headRefName: String, statusChecks: [StatusCheck], reviewDecision: ReviewDecision?) {
         let json = try await shellExecutor.execute(
             command: "gh",
             arguments: [
                 "pr", "view", "\(number)",
                 "--repo", "\(owner)/\(repo)",
                 "--json", "headRefName,statusCheckRollup,mergeable,mergeStateStatus,reviewDecision"
-            ]
+            ],
+            host: host
         )
 
         guard let jsonData = json.data(using: .utf8) else {

--- a/MonitorLizard/Services/ShellExecutor.swift
+++ b/MonitorLizard/Services/ShellExecutor.swift
@@ -21,7 +21,7 @@ enum ShellError: Error {
 }
 
 actor ShellExecutor {
-    func execute(command: String, arguments: [String] = [], timeout: TimeInterval = 30) async throws -> String {
+    func execute(command: String, arguments: [String] = [], timeout: TimeInterval = 30, host: String? = nil) async throws -> String {
         let process = Process()
 
         // Set up the process
@@ -39,6 +39,12 @@ actor ShellExecutor {
         let existingPath = environment["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin"
         let newPath = (homebrewPaths + [existingPath]).joined(separator: ":")
         environment["PATH"] = newPath
+
+        // Set GH_HOST to target a specific GitHub host (e.g. enterprise)
+        if let host = host {
+            environment["GH_HOST"] = host
+        }
+
         process.environment = environment
 
         // Set up pipes for output and error
@@ -108,6 +114,38 @@ actor ShellExecutor {
         }
 
         return output.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Returns all GitHub hosts the user is authenticated with (e.g. ["github.com", "github.enterprise.com"])
+    func getAuthenticatedHosts() async throws -> [String] {
+        do {
+            let output = try await execute(command: "gh", arguments: ["auth", "status"])
+            return parseHosts(from: output)
+        } catch let ShellError.executionFailed(message) {
+            // gh auth status exits with non-zero if any host has issues,
+            // but still prints host info to stderr/stdout
+            return parseHosts(from: message)
+        } catch {
+            return ["github.com"]  // Fallback to default
+        }
+    }
+
+    private func parseHosts(from output: String) -> [String] {
+        // gh auth status output has hostnames at the start of lines (no leading whitespace)
+        // e.g.:
+        // github.com
+        //   ✓ Logged in to github.com account user (keyring)
+        // enterprise.example.com
+        //   ✓ Logged in to enterprise.example.com account user (keyring)
+        var hosts: [String] = []
+        for line in output.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            // Host lines start at column 0 (no leading whitespace) and contain a dot
+            if !trimmed.isEmpty && !line.hasPrefix(" ") && !line.hasPrefix("\t") && trimmed.contains(".") && !trimmed.contains(" ") {
+                hosts.append(trimmed)
+            }
+        }
+        return hosts.isEmpty ? ["github.com"] : hosts
     }
 
     func checkGHInstalled() async throws -> Bool {


### PR DESCRIPTION
## Summary
- Automatically detects all authenticated GitHub hosts via `gh auth status` (github.com + any enterprise instances)
- Queries each host for PRs and merges results, so users with both personal and enterprise accounts see all their PRs
- Passes `GH_HOST` environment variable through to all `gh` CLI calls so status checks and PR details also work against enterprise hosts

## Test plan
- [ ] Verify existing github.com-only users see no change in behavior
- [ ] Verify a user authenticated with both github.com and a GitHub Enterprise host sees PRs from both
- [ ] Verify PR status checks load correctly for enterprise PRs
- [ ] Verify clicking an enterprise PR opens the correct enterprise URL