### PR TITLE
Fix review decision staying CHANGES_REQUESTED after re-request

### DIFF
--- a/MonitorLizard/Models/PullRequest.swift
+++ b/MonitorLizard/Models/PullRequest.swift
@@ -127,7 +127,7 @@ struct GHPRSearchResponse: Codable {
     }
 }
 
-/// Combined response for `gh pr view --json number,title,url,author,updatedAt,labels,isDraft,headRefName,statusCheckRollup,mergeable,mergeStateStatus,reviewDecision,state`
+/// Combined response for `gh pr view --json number,title,url,author,updatedAt,labels,isDraft,headRefName,statusCheckRollup,mergeable,mergeStateStatus,reviewDecision,latestReviews,reviewRequests,state`
 struct GHPRViewResponse: Codable {
     let number: Int
     let title: String
@@ -141,6 +141,8 @@ struct GHPRViewResponse: Codable {
     let mergeable: String?
     let mergeStateStatus: String?
     let reviewDecision: String?
+    let latestReviews: [GHPRDetailResponse.Review]?
+    let reviewRequests: [GHPRDetailResponse.ReviewRequest]?
     let state: String
 
     struct Author: Codable {
@@ -160,6 +162,21 @@ struct GHPRDetailResponse: Codable {
     let mergeable: String?
     let mergeStateStatus: String?
     let reviewDecision: String?
+    let latestReviews: [Review]?
+    let reviewRequests: [ReviewRequest]?
+
+    struct Review: Codable {
+        let author: ReviewAuthor?
+        let state: String
+
+        struct ReviewAuthor: Codable {
+            let login: String
+        }
+    }
+
+    struct ReviewRequest: Codable {
+        let login: String?  // nil for team review requests
+    }
 
     struct StatusCheck: Codable {
         let name: String?

--- a/MonitorLizard/Services/GitHubService.swift
+++ b/MonitorLizard/Services/GitHubService.swift
@@ -363,7 +363,7 @@ class GitHubService: ObservableObject {
             inactiveThresholdDays: inactiveThresholdDays
         )
 
-        let reviewDecision = resolveReviewDecision(
+        let reviewDecision = Self.resolveReviewDecision(
             rawValue: detail.reviewDecision,
             latestReviews: detail.latestReviews,
             reviewRequests: detail.reviewRequests
@@ -377,7 +377,7 @@ class GitHubService: ObservableObject {
     /// GitHub's `reviewDecision` field stays `CHANGES_REQUESTED` even after an author
     /// re-requests a review. If every reviewer who requested changes has since been
     /// re-requested, the effective state should be `REVIEW_REQUIRED` instead.
-    private func resolveReviewDecision(
+    nonisolated static func resolveReviewDecision(
         rawValue: String?,
         latestReviews: [GHPRDetailResponse.Review]?,
         reviewRequests: [GHPRDetailResponse.ReviewRequest]?
@@ -631,7 +631,7 @@ class GitHubService: ObservableObject {
                 enableInactiveDetection: enableInactiveDetection,
                 inactiveThresholdDays: inactiveThresholdDays
             )
-            let reviewDecision = resolveReviewDecision(
+            let reviewDecision = Self.resolveReviewDecision(
                 rawValue: response.reviewDecision,
                 latestReviews: response.latestReviews,
                 reviewRequests: response.reviewRequests

--- a/MonitorLizard/Services/GitHubService.swift
+++ b/MonitorLizard/Services/GitHubService.swift
@@ -393,10 +393,19 @@ class GitHubService: ObservableObject {
 
         // If every CHANGES_REQUESTED reviewer has a pending re-review request,
         // the author has addressed the feedback and is awaiting a new review.
-        let allReRequested = !changesRequestedLogins.isEmpty &&
-            changesRequestedLogins.allSatisfy { pendingLogins.contains($0) }
+        if !changesRequestedLogins.isEmpty {
+            let allReRequested = changesRequestedLogins.allSatisfy { pendingLogins.contains($0) }
+            return allReRequested ? .reviewRequired : .changesRequested
+        }
 
-        return allReRequested ? .reviewRequired : .changesRequested
+        // GitHub sometimes returns latestReviews without the CHANGES_REQUESTED entry
+        // (e.g., older reviews fall off). If the API says CHANGES_REQUESTED but we can't
+        // find who requested changes, fall back to checking whether any re-review is pending.
+        if !pendingLogins.isEmpty {
+            return .reviewRequired
+        }
+
+        return .changesRequested
     }
 
     private func parseOverallStatus(from checks: [GHPRDetailResponse.StatusCheck]?, mergeable: String?, mergeStateStatus: String?, updatedAt: Date, enableInactiveDetection: Bool, inactiveThresholdDays: Int) -> BuildStatus {

--- a/MonitorLizard/Services/GitHubService.swift
+++ b/MonitorLizard/Services/GitHubService.swift
@@ -340,7 +340,7 @@ class GitHubService: ObservableObject {
             arguments: [
                 "pr", "view", "\(number)",
                 "--repo", "\(owner)/\(repo)",
-                "--json", "headRefName,statusCheckRollup,mergeable,mergeStateStatus,reviewDecision"
+                "--json", "headRefName,statusCheckRollup,mergeable,mergeStateStatus,reviewDecision,latestReviews,reviewRequests"
             ],
             host: host
         )
@@ -363,9 +363,40 @@ class GitHubService: ObservableObject {
             inactiveThresholdDays: inactiveThresholdDays
         )
 
-        let reviewDecision = ReviewDecision(rawValue: detail.reviewDecision?.uppercased() ?? "")
+        let reviewDecision = resolveReviewDecision(
+            rawValue: detail.reviewDecision,
+            latestReviews: detail.latestReviews,
+            reviewRequests: detail.reviewRequests
+        )
 
         return (status, detail.headRefName, statusChecks, reviewDecision)
+    }
+
+    /// Resolves the effective review decision, accounting for re-requested reviews.
+    ///
+    /// GitHub's `reviewDecision` field stays `CHANGES_REQUESTED` even after an author
+    /// re-requests a review. If every reviewer who requested changes has since been
+    /// re-requested, the effective state should be `REVIEW_REQUIRED` instead.
+    private func resolveReviewDecision(
+        rawValue: String?,
+        latestReviews: [GHPRDetailResponse.Review]?,
+        reviewRequests: [GHPRDetailResponse.ReviewRequest]?
+    ) -> ReviewDecision? {
+        guard let rawValue, rawValue.uppercased() == "CHANGES_REQUESTED" else {
+            return ReviewDecision(rawValue: rawValue?.uppercased() ?? "")
+        }
+
+        let pendingLogins = Set((reviewRequests ?? []).compactMap { $0.login })
+        let changesRequestedLogins = (latestReviews ?? [])
+            .filter { $0.state.uppercased() == "CHANGES_REQUESTED" }
+            .compactMap { $0.author?.login }
+
+        // If every CHANGES_REQUESTED reviewer has a pending re-review request,
+        // the author has addressed the feedback and is awaiting a new review.
+        let allReRequested = !changesRequestedLogins.isEmpty &&
+            changesRequestedLogins.allSatisfy { pendingLogins.contains($0) }
+
+        return allReRequested ? .reviewRequired : .changesRequested
     }
 
     private func parseOverallStatus(from checks: [GHPRDetailResponse.StatusCheck]?, mergeable: String?, mergeStateStatus: String?, updatedAt: Date, enableInactiveDetection: Bool, inactiveThresholdDays: Int) -> BuildStatus {
@@ -578,7 +609,7 @@ class GitHubService: ObservableObject {
                 arguments: [
                     "pr", "view", "\(id.number)",
                     "--repo", "\(id.owner)/\(id.repo)",
-                    "--json", "number,title,url,author,updatedAt,labels,isDraft,headRefName,statusCheckRollup,mergeable,mergeStateStatus,reviewDecision,state"
+                    "--json", "number,title,url,author,updatedAt,labels,isDraft,headRefName,statusCheckRollup,mergeable,mergeStateStatus,reviewDecision,latestReviews,reviewRequests,state"
                 ],
                 host: id.host
             )
@@ -600,7 +631,11 @@ class GitHubService: ObservableObject {
                 enableInactiveDetection: enableInactiveDetection,
                 inactiveThresholdDays: inactiveThresholdDays
             )
-            let reviewDecision = ReviewDecision(rawValue: response.reviewDecision?.uppercased() ?? "")
+            let reviewDecision = resolveReviewDecision(
+                rawValue: response.reviewDecision,
+                latestReviews: response.latestReviews,
+                reviewRequests: response.reviewRequests
+            )
 
             return PullRequest(
                 number: response.number,

--- a/MonitorLizardTests/PRMonitorViewModelTests.swift
+++ b/MonitorLizardTests/PRMonitorViewModelTests.swift
@@ -2,6 +2,157 @@ import Testing
 import Foundation
 @testable import MonitorLizard
 
+struct ResolveReviewDecisionTests {
+
+    private typealias Review = GHPRDetailResponse.Review
+    private typealias ReviewAuthor = GHPRDetailResponse.Review.ReviewAuthor
+    private typealias ReviewRequest = GHPRDetailResponse.ReviewRequest
+
+    private func review(_ login: String, state: String) -> Review {
+        Review(author: ReviewAuthor(login: login), state: state)
+    }
+
+    private func request(_ login: String) -> ReviewRequest {
+        ReviewRequest(login: login)
+    }
+
+    // MARK: Non-CHANGES_REQUESTED pass-throughs
+
+    @Test func approvedPassesThrough() {
+        let result = GitHubService.resolveReviewDecision(rawValue: "APPROVED", latestReviews: nil, reviewRequests: nil)
+        #expect(result == .approved)
+    }
+
+    @Test func reviewRequiredPassesThrough() {
+        let result = GitHubService.resolveReviewDecision(rawValue: "REVIEW_REQUIRED", latestReviews: nil, reviewRequests: nil)
+        #expect(result == .reviewRequired)
+    }
+
+    @Test func nilRawValueReturnsNil() {
+        let result = GitHubService.resolveReviewDecision(rawValue: nil, latestReviews: nil, reviewRequests: nil)
+        #expect(result == nil)
+    }
+
+    // MARK: CHANGES_REQUESTED with no re-request
+
+    @Test func changesRequestedWithNoReviewRequestsStaysChangesRequested() {
+        let result = GitHubService.resolveReviewDecision(
+            rawValue: "CHANGES_REQUESTED",
+            latestReviews: [review("alice", state: "CHANGES_REQUESTED")],
+            reviewRequests: []
+        )
+        #expect(result == .changesRequested)
+    }
+
+    @Test func changesRequestedWithNilReviewRequestsStaysChangesRequested() {
+        let result = GitHubService.resolveReviewDecision(
+            rawValue: "CHANGES_REQUESTED",
+            latestReviews: [review("alice", state: "CHANGES_REQUESTED")],
+            reviewRequests: nil
+        )
+        #expect(result == .changesRequested)
+    }
+
+    @Test func changesRequestedWhenDifferentReviewerReRequestedStaysChangesRequested() {
+        // alice requested changes, but only bob has a pending re-review
+        let result = GitHubService.resolveReviewDecision(
+            rawValue: "CHANGES_REQUESTED",
+            latestReviews: [review("alice", state: "CHANGES_REQUESTED")],
+            reviewRequests: [request("bob")]
+        )
+        #expect(result == .changesRequested)
+    }
+
+    @Test func changesRequestedWhenOnlyOneOfTwoReRequestedStaysChangesRequested() {
+        // Both alice and bob requested changes; only alice re-requested
+        let result = GitHubService.resolveReviewDecision(
+            rawValue: "CHANGES_REQUESTED",
+            latestReviews: [
+                review("alice", state: "CHANGES_REQUESTED"),
+                review("bob", state: "CHANGES_REQUESTED")
+            ],
+            reviewRequests: [request("alice")]
+        )
+        #expect(result == .changesRequested)
+    }
+
+    // MARK: CHANGES_REQUESTED downgraded to REVIEW_REQUIRED
+
+    @Test func changesRequestedDowngradedWhenReviewerReRequested() {
+        let result = GitHubService.resolveReviewDecision(
+            rawValue: "CHANGES_REQUESTED",
+            latestReviews: [review("alice", state: "CHANGES_REQUESTED")],
+            reviewRequests: [request("alice")]
+        )
+        #expect(result == .reviewRequired)
+    }
+
+    @Test func changesRequestedDowngradedWhenAllReviewersReRequested() {
+        let result = GitHubService.resolveReviewDecision(
+            rawValue: "CHANGES_REQUESTED",
+            latestReviews: [
+                review("alice", state: "CHANGES_REQUESTED"),
+                review("bob", state: "CHANGES_REQUESTED")
+            ],
+            reviewRequests: [request("alice"), request("bob")]
+        )
+        #expect(result == .reviewRequired)
+    }
+
+    @Test func changesRequestedDowngradedWhenMixedReviewsAndAllChangesReRequesters() {
+        // alice approved, bob requested changes and has been re-requested
+        let result = GitHubService.resolveReviewDecision(
+            rawValue: "CHANGES_REQUESTED",
+            latestReviews: [
+                review("alice", state: "APPROVED"),
+                review("bob", state: "CHANGES_REQUESTED")
+            ],
+            reviewRequests: [request("bob")]
+        )
+        #expect(result == .reviewRequired)
+    }
+
+    // MARK: Edge cases
+
+    @Test func changesRequestedWithNoLatestReviewsStaysChangesRequested() {
+        // No latestReviews means we can't confirm who requested changes — stay conservative
+        let result = GitHubService.resolveReviewDecision(
+            rawValue: "CHANGES_REQUESTED",
+            latestReviews: nil,
+            reviewRequests: [request("alice")]
+        )
+        #expect(result == .changesRequested)
+    }
+
+    @Test func changesRequestedWithEmptyLatestReviewsStaysChangesRequested() {
+        let result = GitHubService.resolveReviewDecision(
+            rawValue: "CHANGES_REQUESTED",
+            latestReviews: [],
+            reviewRequests: [request("alice")]
+        )
+        #expect(result == .changesRequested)
+    }
+
+    @Test func teamReviewRequestIgnoredGracefully() {
+        // Team review requests have nil login — should not crash or incorrectly downgrade
+        let result = GitHubService.resolveReviewDecision(
+            rawValue: "CHANGES_REQUESTED",
+            latestReviews: [review("alice", state: "CHANGES_REQUESTED")],
+            reviewRequests: [ReviewRequest(login: nil)]
+        )
+        #expect(result == .changesRequested)
+    }
+
+    @Test func caseInsensitiveRawValue() {
+        let result = GitHubService.resolveReviewDecision(
+            rawValue: "changes_requested",
+            latestReviews: [review("alice", state: "CHANGES_REQUESTED")],
+            reviewRequests: [request("alice")]
+        )
+        #expect(result == .reviewRequired)
+    }
+}
+
 struct ParsePRURLTests {
 
     @Test func validGitHubURL() {

--- a/MonitorLizardTests/PRMonitorViewModelTests.swift
+++ b/MonitorLizardTests/PRMonitorViewModelTests.swift
@@ -114,21 +114,31 @@ struct ResolveReviewDecisionTests {
 
     // MARK: Edge cases
 
-    @Test func changesRequestedWithNoLatestReviewsStaysChangesRequested() {
-        // No latestReviews means we can't confirm who requested changes — stay conservative
+    @Test func changesRequestedWithNoLatestReviewsAndPendingRequestBecomesReviewRequired() {
+        // GitHub sometimes returns latestReviews empty even when reviewDecision is CHANGES_REQUESTED.
+        // If there's a pending re-review, treat it as reviewRequired.
         let result = GitHubService.resolveReviewDecision(
             rawValue: "CHANGES_REQUESTED",
             latestReviews: nil,
             reviewRequests: [request("alice")]
         )
-        #expect(result == .changesRequested)
+        #expect(result == .reviewRequired)
     }
 
-    @Test func changesRequestedWithEmptyLatestReviewsStaysChangesRequested() {
+    @Test func changesRequestedWithEmptyLatestReviewsAndPendingRequestBecomesReviewRequired() {
         let result = GitHubService.resolveReviewDecision(
             rawValue: "CHANGES_REQUESTED",
             latestReviews: [],
             reviewRequests: [request("alice")]
+        )
+        #expect(result == .reviewRequired)
+    }
+
+    @Test func changesRequestedWithEmptyLatestReviewsAndNoRequestsStaysChangesRequested() {
+        let result = GitHubService.resolveReviewDecision(
+            rawValue: "CHANGES_REQUESTED",
+            latestReviews: [],
+            reviewRequests: []
         )
         #expect(result == .changesRequested)
     }


### PR DESCRIPTION
## Summary

Fixes #6 (reported by @lukelabonte).

- Fetches `latestReviews` and `reviewRequests` alongside `reviewDecision` in both `fetchPRStatus()` and `fetchOtherPR()`
- Adds `resolveReviewDecision()` helper: when `reviewDecision` is `CHANGES_REQUESTED`, cross-references the two lists — if every reviewer who requested changes is also in the pending re-review list, returns `.reviewRequired` instead
- No change in behavior for approved PRs or PRs with genuinely outstanding change requests

## Root cause

GitHub's `reviewDecision` field stays `CHANGES_REQUESTED` even after the author re-requests a review from the same reviewer. The fix uses `reviewRequests` (pending re-reviews) to detect this case and downgrade the displayed state to "Review required".

## Test plan

- [ ] Open a PR where a reviewer has requested changes, then re-request their review — MonitorLizard should now show "Review required" instead of "Changes requested"
- [ ] Open a PR where a reviewer has requested changes and has *not* been re-requested — should still show "Changes requested"
- [ ] Approved PRs unaffected