### PR TITLE
Update Report Issue url to the repo's issues page

### DIFF
--- a/MonitorLizard/Views/SettingsView.swift
+++ b/MonitorLizard/Views/SettingsView.swift
@@ -227,7 +227,7 @@ struct SettingsView: View {
                     }
 
                     Button("Report Issue") {
-                        if let url = URL(string: "https://github.com") {
+                        if let url = URL(string: "https://github.com/SeanMcTex/MonitorLizard/issues") {
                             NSWorkspace.shared.open(url)
                         }
                     }


### PR DESCRIPTION
Hey Sean!! I saw your post on Mastodon about this and have enjoyed using it to keep on top of PRs lately.

I was poking around Settings and noticed that the Report Issue button launched github.com rather than the repo's Issues page, so here's a PR to update that.

Thanks for the useful tool 🙌 