### PR TITLE
fix: quit button doesn't response

### DIFF
--- a/MonitorLizard/MonitorLizardApp.swift
+++ b/MonitorLizard/MonitorLizardApp.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 
+#if DEBUG
 final class DebugAppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         print("[DEBUG] applicationDidFinishLaunching fired")
@@ -11,10 +12,13 @@ final class DebugAppDelegate: NSObject, NSApplicationDelegate {
         return .terminateCancel
     }
 }
+#endif
 
 @main
 struct MonitorLizardApp: App {
+    #if DEBUG
     @NSApplicationDelegateAdaptor(DebugAppDelegate.self) var appDelegate
+    #endif
 
     @StateObject private var viewModel = {
         let isDemoMode = CommandLine.arguments.contains("--demo-mode")


### PR DESCRIPTION
Wrap DebugAppDelegate in #if DEBUG so applicationShouldTerminate no longer returns .terminateCancel in Release builds.