### PR TITLE
fix: PR row hover state bleeds into footer area

### DIFF
--- a/MonitorLizard/Views/MenuBarView.swift
+++ b/MonitorLizard/Views/MenuBarView.swift
@@ -7,6 +7,7 @@ struct MenuBarView: View {
     // when the panel is hidden. Swapping in an empty placeholder when not visible
     // reduces per-frame work to nearly nothing.
     @State private var isWindowVisible = true
+    @State private var isScrollViewHovered = false
 
     var body: some View {
         // WindowOcclusionObserver watches the specific NSWindow this view lives in
@@ -49,6 +50,11 @@ struct MenuBarView: View {
 
             // Footer
             footerView
+                .onContinuousHover { phase in
+                    if case .active = phase {
+                        isScrollViewHovered = false
+                    }
+                }
         }
         .frame(minWidth: 400, maxWidth: 500)
     }
@@ -237,6 +243,13 @@ struct MenuBarView: View {
                 }
             }
             .frame(height: targetHeight)
+            .onContinuousHover { phase in
+                switch phase {
+                case .active: isScrollViewHovered = true
+                case .ended: isScrollViewHovered = false
+                }
+            }
+            .environment(\.scrollViewHovered, isScrollViewHovered)
             .id(viewModel.selectedRepository)
             .onAppear {
                 proxy.scrollTo("top", anchor: .top)

--- a/MonitorLizard/Views/PRRowView.swift
+++ b/MonitorLizard/Views/PRRowView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 private struct ScrollViewHoveredKey: EnvironmentKey {
+    // Default true so rows outside the scroll view context don't have their hover cleared.
     static let defaultValue = true
 }
 

--- a/MonitorLizard/Views/PRRowView.swift
+++ b/MonitorLizard/Views/PRRowView.swift
@@ -1,5 +1,16 @@
 import SwiftUI
 
+private struct ScrollViewHoveredKey: EnvironmentKey {
+    static let defaultValue = true
+}
+
+extension EnvironmentValues {
+    var scrollViewHovered: Bool {
+        get { self[ScrollViewHoveredKey.self] }
+        set { self[ScrollViewHoveredKey.self] = newValue }
+    }
+}
+
 extension ReviewDecision {
     var color: Color {
         switch self {
@@ -13,6 +24,7 @@ extension ReviewDecision {
 struct PRRowView: View {
     let pr: PullRequest
     @EnvironmentObject var viewModel: PRMonitorViewModel
+    @Environment(\.scrollViewHovered) private var scrollViewHovered
 
     @State private var isHovering = false
 
@@ -354,6 +366,9 @@ struct PRRowView: View {
             case .ended:
                 if isHovering { isHovering = false }
             }
+        }
+        .onChange(of: scrollViewHovered) { hovered in
+            if !hovered && isHovering { isHovering = false }
         }
         .onTapGesture {
             openPRURL()


### PR DESCRIPTION
when mouse is at footer area, the PR item is at hover state

<img width="800" height="1492" alt="image" src="https://github.com/user-attachments/assets/0d6eaa31-44a6-4f8e-a1bf-eec7a676b0a6" />

