### PR TITLE
fix: PR number displays with thousands separator

### DIFF
--- a/MonitorLizard/Views/PRRowView.swift
+++ b/MonitorLizard/Views/PRRowView.swift
@@ -174,7 +174,7 @@ struct PRRowView: View {
                         .font(.caption)
                         .foregroundColor(.secondary)
 
-                    Text("#\(pr.number)")
+                    Text("#\(pr.number, format: .number.grouping(.never))")
                         .font(.caption)
                         .foregroundColor(.secondary)
 


### PR DESCRIPTION
Prevent macOS locale from inserting commas in large PR numbers like #71,922.