### PR TITLE
fix: Calculate PR update date as 'today' while it is actually yesterday

### DIFF
--- a/MonitorLizard/MonitorLizard.xcodeproj/project.pbxproj
+++ b/MonitorLizard/MonitorLizard.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		32TESTS042F4A000000000001 /* GitHubServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32TESTS042F4A000000000000 /* GitHubServiceTests.swift */; };
 		32TESTS052F4A000000000001 /* ShellExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32TESTS052F4A000000000000 /* ShellExecutorTests.swift */; };
 		32TESTS062F4A000000000001 /* PRCacheServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32TESTS062F4A000000000000 /* PRCacheServiceTests.swift */; };
+		32TESTS072F4A000000000001 /* PRRowViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32TESTS072F4A000000000000 /* PRRowViewTests.swift */; };
 		A8C2D4E19F7B4A2D9E3B7C41 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7BF1FEEFD8924EFA85A1FE55 /* Assets.xcassets */; };
 		AA0001112F103E3200F0ABCD /* OtherPRsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0002222F103E3200F0ABCD /* OtherPRsService.swift */; };
 		AA0003332F103E3200F0ABCD /* AddPRView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0004442F103E3200F0ABCD /* AddPRView.swift */; };
@@ -74,6 +75,7 @@
 		32TESTS042F4A000000000000 /* GitHubServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitHubServiceTests.swift; sourceTree = "<group>"; };
 		32TESTS052F4A000000000000 /* ShellExecutorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShellExecutorTests.swift; sourceTree = "<group>"; };
 		32TESTS062F4A000000000000 /* PRCacheServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRCacheServiceTests.swift; sourceTree = "<group>"; };
+		32TESTS072F4A000000000000 /* PRRowViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRRowViewTests.swift; sourceTree = "<group>"; };
 		7BF1FEEFD8924EFA85A1FE55 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		AA0002222F103E3200F0ABCD /* OtherPRsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherPRsService.swift; sourceTree = "<group>"; };
 		AA0004442F103E3200F0ABCD /* AddPRView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPRView.swift; sourceTree = "<group>"; };
@@ -189,6 +191,7 @@
 				32TESTS042F4A000000000000 /* GitHubServiceTests.swift */,
 				32TESTS052F4A000000000000 /* ShellExecutorTests.swift */,
 				32TESTS062F4A000000000000 /* PRCacheServiceTests.swift */,
+				32TESTS072F4A000000000000 /* PRRowViewTests.swift */,
 			);
 			name = MonitorLizardTests;
 			path = ../MonitorLizardTests;
@@ -335,6 +338,7 @@
 				32TESTS042F4A000000000001 /* GitHubServiceTests.swift in Sources */,
 				32TESTS052F4A000000000001 /* ShellExecutorTests.swift in Sources */,
 				32TESTS062F4A000000000001 /* PRCacheServiceTests.swift in Sources */,
+				32TESTS072F4A000000000001 /* PRRowViewTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MonitorLizard/Views/PRRowView.swift
+++ b/MonitorLizard/Views/PRRowView.swift
@@ -17,8 +17,10 @@ struct PRRowView: View {
     @State private var isHovering = false
 
     private var daysSinceUpdate: Int {
-        let days = Int(Date().timeIntervalSince(pr.updatedAt) / Constants.secondsPerDay)
-        return days
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let updateDay = calendar.startOfDay(for: pr.updatedAt)
+        return calendar.dateComponents([.day], from: updateDay, to: today).day ?? 0
     }
 
     private func openPRURL() {

--- a/MonitorLizard/Views/PRRowView.swift
+++ b/MonitorLizard/Views/PRRowView.swift
@@ -16,11 +16,14 @@ struct PRRowView: View {
 
     @State private var isHovering = false
 
-    private var daysSinceUpdate: Int {
-        let calendar = Calendar.current
-        let today = calendar.startOfDay(for: Date())
-        let updateDay = calendar.startOfDay(for: pr.updatedAt)
+    static func daysSinceUpdate(from date: Date, now: Date = Date(), calendar: Calendar = .current) -> Int {
+        let today = calendar.startOfDay(for: now)
+        let updateDay = calendar.startOfDay(for: date)
         return calendar.dateComponents([.day], from: updateDay, to: today).day ?? 0
+    }
+
+    private var daysSinceUpdate: Int {
+        PRRowView.daysSinceUpdate(from: pr.updatedAt)
     }
 
     private func openPRURL() {

--- a/MonitorLizardTests/PRRowViewTests.swift
+++ b/MonitorLizardTests/PRRowViewTests.swift
@@ -1,0 +1,34 @@
+import Testing
+import Foundation
+@testable import MonitorLizard
+
+struct DaysSinceUpdateTests {
+
+    // Fixed "now": 2024-01-15 09:00 local time.
+    private let now = Calendar.current.date(from: DateComponents(year: 2024, month: 1, day: 15, hour: 9))!
+
+    private func date(daysAgo: Int, hour: Int = 9, minute: Int = 0) -> Date {
+        Calendar.current.date(from: DateComponents(year: 2024, month: 1, day: 15 - daysAgo, hour: hour, minute: minute))!
+    }
+
+    @Test func updatedTodayReturnsZero() {
+        #expect(PRRowView.daysSinceUpdate(from: date(daysAgo: 0), now: now) == 0)
+    }
+
+    @Test func updatedJustAfterMidnightTodayReturnsZero() {
+        #expect(PRRowView.daysSinceUpdate(from: date(daysAgo: 0, hour: 0, minute: 1), now: now) == 0)
+    }
+
+    @Test func updatedLateLastNightReturnsOne() {
+        // Regression: 23:53 the previous calendar day was previously reported as "today".
+        #expect(PRRowView.daysSinceUpdate(from: date(daysAgo: 1, hour: 23, minute: 53), now: now) == 1)
+    }
+
+    @Test func updatedYesterdayReturnsOne() {
+        #expect(PRRowView.daysSinceUpdate(from: date(daysAgo: 1), now: now) == 1)
+    }
+
+    @Test func updatedTwoDaysAgoReturnsTwo() {
+        #expect(PRRowView.daysSinceUpdate(from: date(daysAgo: 2), now: now) == 2)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -290,6 +290,10 @@ AI-assisted and AI-authored contributions are welcome, but the human submitting 
 - Changes that require a GitHub token or server-side component (the app intentionally uses only the `gh` CLI)
 - Dependencies beyond Swift Package Manager packages
 
+### Testing
+
+Bug fixes should include a test that fails before the fix and passes after. New features should include tests where appropriate and practical. If the logic under test is buried in a private method or tightly coupled to a view, extract it to a `static func` with injectable parameters (date, calendar, etc.) so it can be exercised without UI infrastructure.
+
 ### Code Style
 
 Follow the patterns already in the codebase: MVVM with `@Published`/Combine, actors for thread-safe services, `@AppStorage` for settings. Swift 6 strict concurrency is enabled — all new code must compile without warnings.


### PR DESCRIPTION
A PR's last updatedAt time is yesterday 23:53:02, but it displays as 'today'.