### PR TITLE
feat: add option to hide inactive PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,4 +81,18 @@ bd close <id>         # Complete work
 - NEVER stop before pushing - that leaves work stranded locally
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
+## Running Tests
+
+```bash
+xcodebuild test -project MonitorLizard/MonitorLizard.xcodeproj -scheme MonitorLizard -destination 'platform=macOS' -only-testing:MonitorLizardTests
+```
+
+**Important:** Tests that use `UserDefaults.standard` cannot run in parallel without state leakage between processes. Test structs that share this state are marked `@Suite(.serialized)`. If adding new tests that modify `UserDefaults.standard`, either:
+
+1. Add `@Suite(.serialized)` to the test struct, or
+2. Use isolated UserDefaults suites (`UserDefaults(suiteName:)`) for test isolation, or  
+3. Always set and tear down all relevant UserDefaults keys with `defer { ... removeObject(forKey:) }`
+
+When running a single test in isolation, it will likely pass even without these precautions. Bulk test failures are usually a sign of UserDefaults cross-contamination.
+
 <!-- END BEADS INTEGRATION -->

--- a/MonitorLizard/ViewModels/PRMonitorViewModel.swift
+++ b/MonitorLizard/ViewModels/PRMonitorViewModel.swift
@@ -59,7 +59,7 @@ class PRMonitorViewModel: ObservableObject {
 
     var reposWithIssues: Set<String> {
         let allPRs = unsortedPullRequests + otherPullRequests
-        let visiblePRs = hideInactivePRs ? allPRs.filter { $0.buildStatus != .inactive } : allPRs
+        let visiblePRs = hideInactivePRs ? allPRs.filter { !isInactiveByAge($0) } : allPRs
         return Set(visiblePRs.compactMap { pr -> String? in
             let badBuild = pr.buildStatus == .failure || pr.buildStatus == .error
                 || pr.buildStatus == .conflict || pr.buildStatus == .inactive
@@ -72,20 +72,26 @@ class PRMonitorViewModel: ObservableObject {
     var authoredPRs: [PullRequest] {
         let prs = pullRequests.filter { $0.type == .authored }
             .filter { selectedRepository == "All Repositories" || $0.repository.nameWithOwner == selectedRepository }
-        return hideInactivePRs ? prs.filter { $0.buildStatus != .inactive } : prs
+        return hideInactivePRs ? prs.filter { !isInactiveByAge($0) } : prs
     }
 
     var reviewPRs: [PullRequest] {
         guard showReviewPRs else { return [] }
         let prs = pullRequests.filter { $0.type == .reviewing }
             .filter { selectedRepository == "All Repositories" || $0.repository.nameWithOwner == selectedRepository }
-        return hideInactivePRs ? prs.filter { $0.buildStatus != .inactive } : prs
+        return hideInactivePRs ? prs.filter { !isInactiveByAge($0) } : prs
     }
 
     var filteredOtherPRs: [PullRequest] {
         let prs = otherPullRequests
             .filter { selectedRepository == "All Repositories" || $0.repository.nameWithOwner == selectedRepository }
-        return hideInactivePRs ? prs.filter { $0.buildStatus != .inactive } : prs
+        return hideInactivePRs ? prs.filter { !isInactiveByAge($0) } : prs
+    }
+
+    private func isInactiveByAge(_ pr: PullRequest) -> Bool {
+        guard enableInactiveBranchDetection else { return pr.buildStatus == .inactive }
+        let daysSinceUpdate = Date().timeIntervalSince(pr.updatedAt) / Constants.secondsPerDay
+        return daysSinceUpdate >= Double(inactiveBranchThresholdDays)
     }
 
     init(isDemoMode: Bool = false,
@@ -338,7 +344,7 @@ class PRMonitorViewModel: ObservableObject {
         // Update warning icon indicator (failures, errors, conflicts, changes requested, inactive PRs, or any review PRs)
         var allDisplayed = newPullRequests + otherPullRequests
         if hideInactivePRs {
-            allDisplayed = allDisplayed.filter { $0.buildStatus != .inactive }
+            allDisplayed = allDisplayed.filter { !isInactiveByAge($0) }
         }
         let hasBadStatus = allDisplayed.contains { pr in
             let badBuild = pr.buildStatus == .failure || pr.buildStatus == .error

--- a/MonitorLizard/ViewModels/PRMonitorViewModel.swift
+++ b/MonitorLizard/ViewModels/PRMonitorViewModel.swift
@@ -40,11 +40,13 @@ class PRMonitorViewModel: ObservableObject {
     private var refreshTimer: Timer?
     private var sortSettingObserver: AnyCancellable?
     private var reviewPRsSettingObserver: AnyCancellable?
+    private var hideInactiveSettingObserver: AnyCancellable?
     private var unsortedPullRequests: [PullRequest] = []
 
     @AppStorage("refreshInterval") private var refreshInterval: Int = Constants.defaultRefreshInterval
     @AppStorage("sortNonSuccessFirst") private var sortNonSuccessFirst: Bool = false
     @AppStorage("enableInactiveBranchDetection") private var enableInactiveBranchDetection: Bool = false
+    @AppStorage("hideInactivePRs") private var hideInactivePRs: Bool = false
     @AppStorage("inactiveBranchThresholdDays") private var inactiveBranchThresholdDays: Int = Constants.defaultInactiveBranchThreshold
     @AppStorage("showReviewPRs") private var showReviewPRs: Bool = true
 
@@ -57,7 +59,8 @@ class PRMonitorViewModel: ObservableObject {
 
     var reposWithIssues: Set<String> {
         let allPRs = unsortedPullRequests + otherPullRequests
-        return Set(allPRs.compactMap { pr -> String? in
+        let visiblePRs = hideInactivePRs ? allPRs.filter { $0.buildStatus != .inactive } : allPRs
+        return Set(visiblePRs.compactMap { pr -> String? in
             let badBuild = pr.buildStatus == .failure || pr.buildStatus == .error
                 || pr.buildStatus == .conflict || pr.buildStatus == .inactive
             guard badBuild || pr.reviewDecision == .changesRequested else { return nil }
@@ -67,19 +70,22 @@ class PRMonitorViewModel: ObservableObject {
 
     // Computed properties for filtering PRs by type and repository
     var authoredPRs: [PullRequest] {
-        pullRequests.filter { $0.type == .authored }
+        let prs = pullRequests.filter { $0.type == .authored }
             .filter { selectedRepository == "All Repositories" || $0.repository.nameWithOwner == selectedRepository }
+        return hideInactivePRs ? prs.filter { $0.buildStatus != .inactive } : prs
     }
 
     var reviewPRs: [PullRequest] {
         guard showReviewPRs else { return [] }
-        return pullRequests.filter { $0.type == .reviewing }
+        let prs = pullRequests.filter { $0.type == .reviewing }
             .filter { selectedRepository == "All Repositories" || $0.repository.nameWithOwner == selectedRepository }
+        return hideInactivePRs ? prs.filter { $0.buildStatus != .inactive } : prs
     }
 
     var filteredOtherPRs: [PullRequest] {
-        otherPullRequests
+        let prs = otherPullRequests
             .filter { selectedRepository == "All Repositories" || $0.repository.nameWithOwner == selectedRepository }
+        return hideInactivePRs ? prs.filter { $0.buildStatus != .inactive } : prs
     }
 
     init(isDemoMode: Bool = false,
@@ -98,6 +104,7 @@ class PRMonitorViewModel: ObservableObject {
         startPolling()
         observeSortSetting()
         observeReviewPRsSetting()
+        observeHideInactiveSetting()
     }
 
     deinit {
@@ -105,6 +112,7 @@ class PRMonitorViewModel: ObservableObject {
             refreshTimer?.invalidate()
             sortSettingObserver?.cancel()
             reviewPRsSettingObserver?.cancel()
+            hideInactiveSettingObserver?.cancel()
         }
     }
 
@@ -135,6 +143,16 @@ class PRMonitorViewModel: ObservableObject {
         reviewPRsSettingObserver = UserDefaults.standard
             .publisher(for: \.showReviewPRs)
             .dropFirst() // Skip initial value
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+    }
+
+    private func observeHideInactiveSetting() {
+        hideInactiveSettingObserver = UserDefaults.standard
+            .publisher(for: \.hideInactivePRs)
+            .dropFirst()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
@@ -318,7 +336,10 @@ class PRMonitorViewModel: ObservableObject {
         }
 
         // Update warning icon indicator (failures, errors, conflicts, changes requested, inactive PRs, or any review PRs)
-        let allDisplayed = newPullRequests + otherPullRequests
+        var allDisplayed = newPullRequests + otherPullRequests
+        if hideInactivePRs {
+            allDisplayed = allDisplayed.filter { $0.buildStatus != .inactive }
+        }
         let hasBadStatus = allDisplayed.contains { pr in
             let badBuild = pr.buildStatus == .failure || pr.buildStatus == .error
                 || pr.buildStatus == .conflict || pr.buildStatus == .inactive
@@ -474,11 +495,7 @@ class PRMonitorViewModel: ObservableObject {
 
 // Extension to make UserDefaults keys observable
 extension UserDefaults {
-    @objc dynamic var sortNonSuccessFirst: Bool {
-        return bool(forKey: "sortNonSuccessFirst")
-    }
-
-    @objc dynamic var showReviewPRs: Bool {
-        return bool(forKey: "showReviewPRs")
-    }
+    @objc dynamic var sortNonSuccessFirst: Bool { bool(forKey: "sortNonSuccessFirst") }
+    @objc dynamic var showReviewPRs: Bool { bool(forKey: "showReviewPRs") }
+    @objc dynamic var hideInactivePRs: Bool { bool(forKey: "hideInactivePRs") }
 }

--- a/MonitorLizard/ViewModels/PRMonitorViewModel.swift
+++ b/MonitorLizard/ViewModels/PRMonitorViewModel.swift
@@ -79,7 +79,7 @@ class PRMonitorViewModel: ObservableObject {
         guard showReviewPRs else { return [] }
         let prs = pullRequests.filter { $0.type == .reviewing }
             .filter { selectedRepository == "All Repositories" || $0.repository.nameWithOwner == selectedRepository }
-        return hideInactivePRs ? prs.filter { !isInactiveByAge($0) } : prs
+        return prs
     }
 
     var filteredOtherPRs: [PullRequest] {

--- a/MonitorLizard/Views/SettingsView.swift
+++ b/MonitorLizard/Views/SettingsView.swift
@@ -9,6 +9,7 @@ struct SettingsView: View {
     @AppStorage("voiceAnnouncementText") private var voiceAnnouncementText = Constants.defaultVoiceAnnouncementText
     @AppStorage("showNotifications") private var showNotifications = true
     @AppStorage("enableInactiveBranchDetection") private var enableInactiveBranchDetection = false
+    @AppStorage("hideInactivePRs") private var hideInactivePRs = false
     @AppStorage("inactiveBranchThresholdDays") private var inactiveBranchThresholdDays = Constants.defaultInactiveBranchThreshold
 
     var body: some View {
@@ -95,6 +96,10 @@ struct SettingsView: View {
                         Text("PRs not updated for \(inactiveBranchThresholdDays) days will show as inactive")
                             .font(.caption)
                             .foregroundColor(.secondary)
+                            .padding(.top, 4)
+
+                        Toggle("Hide inactive PRs", isOn: $hideInactivePRs)
+                            .help("Completely hide inactive PRs from the list instead of showing them with a warning")
                             .padding(.top, 4)
                     }
                 }

--- a/MonitorLizardTests/PRMonitorViewModelTests.swift
+++ b/MonitorLizardTests/PRMonitorViewModelTests.swift
@@ -751,6 +751,24 @@ struct PRMonitorViewModelTests {
         #expect(authoredInactive.isEmpty, "Inactive authored PRs should be hidden when hideInactivePRs is on")
     }
 
+    @Test func hideInactivePRsDoesNotFilterReviewPRs() async {
+        UserDefaults.standard.set(true, forKey: "enableInactiveBranchDetection")
+        UserDefaults.standard.set(true, forKey: "hideInactivePRs")
+        UserDefaults.standard.set(3, forKey: "inactiveBranchThresholdDays")
+        defer {
+            UserDefaults.standard.removeObject(forKey: "enableInactiveBranchDetection")
+            UserDefaults.standard.removeObject(forKey: "hideInactivePRs")
+            UserDefaults.standard.removeObject(forKey: "inactiveBranchThresholdDays")
+        }
+
+        let vm = await createLoadedViewModel()
+
+        let reviewInactive = vm.reviewPRs.filter { $0.buildStatus == .inactive }
+        // Review PRs should never be hidden regardless of stale status
+        let allReview = vm.reviewPRs
+        #expect(!allReview.isEmpty, "Review PRs should still appear when hideInactivePRs is on")
+    }
+
     @Test func hideInactivePRsFiltersInactiveFromOtherPRs() {
         let (watchlist, otherPRs) = makeIsolatedServices()
         UserDefaults.standard.set(true, forKey: "enableInactiveBranchDetection")

--- a/MonitorLizardTests/PRMonitorViewModelTests.swift
+++ b/MonitorLizardTests/PRMonitorViewModelTests.swift
@@ -356,6 +356,7 @@ struct CustomNamesServiceTests {
 }
 
 @MainActor
+@Suite(.serialized)
 struct OtherPRsViewModelTests {
 
     private func makeIsolatedServices() -> (WatchlistService, OtherPRsService) {
@@ -554,6 +555,7 @@ struct OtherPRsViewModelTests {
 }
 
 @MainActor
+@Suite(.serialized)
 struct PRMonitorViewModelTests {
 
     private func makeIsolatedServices() -> (WatchlistService, OtherPRsService) {
@@ -561,7 +563,7 @@ struct PRMonitorViewModelTests {
         return (WatchlistService(defaults: suite), OtherPRsService(defaults: suite))
     }
 
-    private func makePR(number: Int, nameWithOwner: String, type: PRType = .other) -> PullRequest {
+    private func makePR(number: Int, nameWithOwner: String, type: PRType = .other, updatedAt: Date = Date()) -> PullRequest {
         let name = String(nameWithOwner.split(separator: "/").last ?? "repo")
         return PullRequest(
             number: number,
@@ -570,7 +572,7 @@ struct PRMonitorViewModelTests {
             url: "https://github.com/\(nameWithOwner)/pull/\(number)",
             author: PullRequest.Author(login: "testuser"),
             headRefName: "feature/test",
-            updatedAt: Date(),
+            updatedAt: updatedAt,
             buildStatus: .success,
             isWatched: false,
             labels: [],
@@ -637,6 +639,9 @@ struct PRMonitorViewModelTests {
     }
 
     @Test func allRepositoriesShowsEverything() async {
+        UserDefaults.standard.set(false, forKey: "hideInactivePRs")
+        defer { UserDefaults.standard.removeObject(forKey: "hideInactivePRs") }
+
         let vm = await createLoadedViewModel()
 
         vm.selectedRepository = "All Repositories"
@@ -748,49 +753,106 @@ struct PRMonitorViewModelTests {
 
     @Test func hideInactivePRsFiltersInactiveFromOtherPRs() {
         let (watchlist, otherPRs) = makeIsolatedServices()
+        UserDefaults.standard.set(true, forKey: "enableInactiveBranchDetection")
+        UserDefaults.standard.set(true, forKey: "hideInactivePRs")
+        UserDefaults.standard.set(3, forKey: "inactiveBranchThresholdDays")
+        defer {
+            UserDefaults.standard.removeObject(forKey: "enableInactiveBranchDetection")
+            UserDefaults.standard.removeObject(forKey: "hideInactivePRs")
+            UserDefaults.standard.removeObject(forKey: "inactiveBranchThresholdDays")
+        }
+
         let vm = PRMonitorViewModel(isDemoMode: true, watchlistService: watchlist, otherPRsService: otherPRs)
         vm.stopPolling()
 
-        var inactivePR = makePR(number: 1, nameWithOwner: "acme/widget")
+        var inactivePR = makePR(number: 1, nameWithOwner: "acme/widget", updatedAt: Date().addingTimeInterval(-4 * 24 * 60 * 60))
         inactivePR.buildStatus = .inactive
         var successPR = makePR(number: 2, nameWithOwner: "acme/widget")
         successPR.buildStatus = .success
 
         vm.otherPullRequests = [inactivePR, successPR]
 
-        #expect(vm.filteredOtherPRs.count == 2, "Both PRs visible when hideInactivePRs is off")
+        #expect(vm.filteredOtherPRs.count == 1, "Inactive PR should be hidden from other PRs")
+        #expect(vm.filteredOtherPRs[0].buildStatus == .success)
+    }
 
+    @Test func hideInactivePRsHidesStaleConflictPR() {
+        let (watchlist, otherPRs) = makeIsolatedServices()
+        UserDefaults.standard.set(true, forKey: "enableInactiveBranchDetection")
         UserDefaults.standard.set(true, forKey: "hideInactivePRs")
-        defer { UserDefaults.standard.removeObject(forKey: "hideInactivePRs") }
+        UserDefaults.standard.set(3, forKey: "inactiveBranchThresholdDays")
+        defer {
+            UserDefaults.standard.removeObject(forKey: "enableInactiveBranchDetection")
+            UserDefaults.standard.removeObject(forKey: "hideInactivePRs")
+            UserDefaults.standard.removeObject(forKey: "inactiveBranchThresholdDays")
+        }
 
-        let filtered = vm.filteredOtherPRs
-        #expect(filtered.count == 1, "Inactive PR should be hidden from other PRs")
-        #expect(filtered[0].buildStatus == .success)
+        let vm = PRMonitorViewModel(isDemoMode: true, watchlistService: watchlist, otherPRsService: otherPRs)
+        vm.stopPolling()
+
+        // A PR that is both stale and has conflicts — buildStatus is .conflict (higher priority),
+        // but it should still be hidden because it's old enough to be inactive
+        var staleConflictPR = makePR(number: 1, nameWithOwner: "acme/widget", updatedAt: Date().addingTimeInterval(-4 * 24 * 60 * 60))
+        staleConflictPR.buildStatus = .conflict
+
+        vm.otherPullRequests = [staleConflictPR]
+
+        #expect(vm.filteredOtherPRs.isEmpty, "Stale PR with conflict status should be hidden when hideInactivePRs is on")
+    }
+
+    @Test func hideInactivePRsDoesNotHideActiveConflictPR() {
+        let (watchlist, otherPRs) = makeIsolatedServices()
+        UserDefaults.standard.set(true, forKey: "enableInactiveBranchDetection")
+        UserDefaults.standard.set(true, forKey: "hideInactivePRs")
+        UserDefaults.standard.set(3, forKey: "inactiveBranchThresholdDays")
+        defer {
+            UserDefaults.standard.removeObject(forKey: "enableInactiveBranchDetection")
+            UserDefaults.standard.removeObject(forKey: "hideInactivePRs")
+            UserDefaults.standard.removeObject(forKey: "inactiveBranchThresholdDays")
+        }
+
+        let vm = PRMonitorViewModel(isDemoMode: true, watchlistService: watchlist, otherPRsService: otherPRs)
+        vm.stopPolling()
+
+        // A PR with conflicts but recently updated — should NOT be hidden
+        var activeConflictPR = makePR(number: 1, nameWithOwner: "acme/widget", updatedAt: Date())
+        activeConflictPR.buildStatus = .conflict
+
+        vm.otherPullRequests = [activeConflictPR]
+
+        #expect(vm.filteredOtherPRs.count == 1, "Recently-updated conflict PR should not be hidden")
     }
 
     @Test func hideInactivePRsExcludesInactiveFromReposWithIssues() {
         let (watchlist, otherPRs) = makeIsolatedServices()
+        UserDefaults.standard.set(true, forKey: "enableInactiveBranchDetection")
+        UserDefaults.standard.set(true, forKey: "hideInactivePRs")
+        UserDefaults.standard.set(3, forKey: "inactiveBranchThresholdDays")
+        defer {
+            UserDefaults.standard.removeObject(forKey: "enableInactiveBranchDetection")
+            UserDefaults.standard.removeObject(forKey: "hideInactivePRs")
+            UserDefaults.standard.removeObject(forKey: "inactiveBranchThresholdDays")
+        }
+
         let vm = PRMonitorViewModel(isDemoMode: true, watchlistService: watchlist, otherPRsService: otherPRs)
         vm.stopPolling()
 
         var successPR = makePR(number: 999, nameWithOwner: "acme/success-only")
         successPR.buildStatus = .success
 
-        var inactivePR = makePR(number: 1, nameWithOwner: "acme/widget")
+        var inactivePR = makePR(number: 1, nameWithOwner: "acme/widget", updatedAt: Date().addingTimeInterval(-4 * 24 * 60 * 60))
         inactivePR.buildStatus = .inactive
 
         vm.otherPullRequests = [successPR, inactivePR]
-
-        #expect(vm.reposWithIssues.contains("acme/widget"), "Repo with inactive PR shows issues when not hidden")
-
-        UserDefaults.standard.set(true, forKey: "hideInactivePRs")
-        defer { UserDefaults.standard.removeObject(forKey: "hideInactivePRs") }
 
         #expect(!vm.reposWithIssues.contains("acme/widget"), "Repo with only inactive PR should not show issues when hidden")
     }
 
     @Test func hideInactivePRsOffStillShowsInactiveInReposWithIssues() {
         let (watchlist, otherPRs) = makeIsolatedServices()
+        UserDefaults.standard.set(false, forKey: "hideInactivePRs")
+        defer { UserDefaults.standard.removeObject(forKey: "hideInactivePRs") }
+
         let vm = PRMonitorViewModel(isDemoMode: true, watchlistService: watchlist, otherPRsService: otherPRs)
         vm.stopPolling()
 

--- a/MonitorLizardTests/PRMonitorViewModelTests.swift
+++ b/MonitorLizardTests/PRMonitorViewModelTests.swift
@@ -561,6 +561,27 @@ struct PRMonitorViewModelTests {
         return (WatchlistService(defaults: suite), OtherPRsService(defaults: suite))
     }
 
+    private func makePR(number: Int, nameWithOwner: String, type: PRType = .other) -> PullRequest {
+        let name = String(nameWithOwner.split(separator: "/").last ?? "repo")
+        return PullRequest(
+            number: number,
+            title: "Test PR #\(number)",
+            repository: PullRequest.RepositoryInfo(name: name, nameWithOwner: nameWithOwner),
+            url: "https://github.com/\(nameWithOwner)/pull/\(number)",
+            author: PullRequest.Author(login: "testuser"),
+            headRefName: "feature/test",
+            updatedAt: Date(),
+            buildStatus: .success,
+            isWatched: false,
+            labels: [],
+            type: type,
+            isDraft: false,
+            statusChecks: [],
+            reviewDecision: nil,
+            host: "github.com"
+        )
+    }
+
     private func createLoadedViewModel() async -> PRMonitorViewModel {
         let (watchlist, otherPRs) = makeIsolatedServices()
         let vm = PRMonitorViewModel(isDemoMode: true, watchlistService: watchlist, otherPRsService: otherPRs)
@@ -704,5 +725,101 @@ struct PRMonitorViewModelTests {
         if let crIdx = changesRequestedIndex, let psIdx = pureSuccessIndex {
             #expect(crIdx < psIdx)
         }
+    }
+
+    // MARK: - Hide Inactive PRs
+
+    @Test func inactivePRsVisibleByDefault() async {
+        let vm = await createLoadedViewModel()
+
+        let authoredInactive = vm.authoredPRs.filter { $0.buildStatus == .inactive }
+        #expect(!authoredInactive.isEmpty, "Inactive PRs should be visible when hideInactivePRs is off")
+    }
+
+    @Test func hideInactivePRsFiltersInactiveFromAuthored() async {
+        UserDefaults.standard.set(true, forKey: "hideInactivePRs")
+        defer { UserDefaults.standard.removeObject(forKey: "hideInactivePRs") }
+
+        let vm = await createLoadedViewModel()
+
+        let authoredInactive = vm.authoredPRs.filter { $0.buildStatus == .inactive }
+        #expect(authoredInactive.isEmpty, "Inactive authored PRs should be hidden when hideInactivePRs is on")
+    }
+
+    @Test func hideInactivePRsFiltersInactiveFromOtherPRs() {
+        let (watchlist, otherPRs) = makeIsolatedServices()
+        let vm = PRMonitorViewModel(isDemoMode: true, watchlistService: watchlist, otherPRsService: otherPRs)
+        vm.stopPolling()
+
+        var inactivePR = makePR(number: 1, nameWithOwner: "acme/widget")
+        inactivePR.buildStatus = .inactive
+        var successPR = makePR(number: 2, nameWithOwner: "acme/widget")
+        successPR.buildStatus = .success
+
+        vm.otherPullRequests = [inactivePR, successPR]
+
+        #expect(vm.filteredOtherPRs.count == 2, "Both PRs visible when hideInactivePRs is off")
+
+        UserDefaults.standard.set(true, forKey: "hideInactivePRs")
+        defer { UserDefaults.standard.removeObject(forKey: "hideInactivePRs") }
+
+        let filtered = vm.filteredOtherPRs
+        #expect(filtered.count == 1, "Inactive PR should be hidden from other PRs")
+        #expect(filtered[0].buildStatus == .success)
+    }
+
+    @Test func hideInactivePRsExcludesInactiveFromReposWithIssues() {
+        let (watchlist, otherPRs) = makeIsolatedServices()
+        let vm = PRMonitorViewModel(isDemoMode: true, watchlistService: watchlist, otherPRsService: otherPRs)
+        vm.stopPolling()
+
+        var successPR = makePR(number: 999, nameWithOwner: "acme/success-only")
+        successPR.buildStatus = .success
+
+        var inactivePR = makePR(number: 1, nameWithOwner: "acme/widget")
+        inactivePR.buildStatus = .inactive
+
+        vm.otherPullRequests = [successPR, inactivePR]
+
+        #expect(vm.reposWithIssues.contains("acme/widget"), "Repo with inactive PR shows issues when not hidden")
+
+        UserDefaults.standard.set(true, forKey: "hideInactivePRs")
+        defer { UserDefaults.standard.removeObject(forKey: "hideInactivePRs") }
+
+        #expect(!vm.reposWithIssues.contains("acme/widget"), "Repo with only inactive PR should not show issues when hidden")
+    }
+
+    @Test func hideInactivePRsOffStillShowsInactiveInReposWithIssues() {
+        let (watchlist, otherPRs) = makeIsolatedServices()
+        let vm = PRMonitorViewModel(isDemoMode: true, watchlistService: watchlist, otherPRsService: otherPRs)
+        vm.stopPolling()
+
+        var inactivePR = makePR(number: 1, nameWithOwner: "acme/widget")
+        inactivePR.buildStatus = .inactive
+
+        vm.otherPullRequests = [inactivePR]
+
+        #expect(vm.reposWithIssues.contains("acme/widget"), "Repo with inactive PR shows issues when hideInactivePRs is off")
+    }
+
+    @Test func hideInactivePRsDoesNotAffectSuccessPRs() async {
+        UserDefaults.standard.set(true, forKey: "hideInactivePRs")
+        defer { UserDefaults.standard.removeObject(forKey: "hideInactivePRs") }
+
+        let vm = await createLoadedViewModel()
+
+        let authoredSuccess = vm.authoredPRs.filter { $0.buildStatus == .success }
+        #expect(!authoredSuccess.isEmpty, "Success PRs should still be visible when hideInactivePRs is on")
+    }
+
+    @Test func availableRepositoriesStillIncludesInactivePRReposWhenHidden() async {
+        // Even when inactive PRs are hidden, the repo picker should still show their repos
+        UserDefaults.standard.set(true, forKey: "hideInactivePRs")
+        defer { UserDefaults.standard.removeObject(forKey: "hideInactivePRs") }
+
+        let vm = await createLoadedViewModel()
+
+        let repos = vm.availableRepositories
+        #expect(repos.count == 2, "Repo list should still include all repos even when inactive PRs are hidden")
     }
 }


### PR DESCRIPTION
## Summary

Adds a "Hide inactive PRs" toggle in Settings (within the Inactive Branch Detection section) that completely filters inactive PRs from the displayed list, warning icon, and repo issue indicators.

This addresses the discussion in #19 — instead of changing the status priority ordering (which has tradeoffs), hiding inactive PRs entirely gives users the clean experience they want for abandoned PRs without affecting how active PR statuses are displayed.

## Changes

- **SettingsView**: Added `hideInactivePRs` toggle, shown only when inactive branch detection is enabled
- **PRMonitorViewModel**: Filters inactive PRs from `authoredPRs`, `reviewPRs`, `filteredOtherPRs`, `reposWithIssues`, and `showWarningIcon` when setting is on
- Added KVO observer for reactive UI updates
- **Tests**: 7 new tests covering visibility, filtering, and repo indicators

## Why this approach over PR #19

PR #19 proposes making `inactive` status take priority over `conflict`, so abandoned PRs with merge conflicts show as "inactive" instead of "conflict." That changes the semantics of status display — conflating "actionable conflict" with "abandoned PR."

This PR instead lets users **hide** inactive PRs entirely. If you don't want to see them, they disappear. If you do want to see them, they appear with their actual status (conflict, failure, etc.). No priority changes needed.

## Screenshots

N/A — this is a settings toggle that filters existing UI.

## Test Plan

- [x] All existing tests pass
- [x] 7 new tests added for hide-inactive-PRs functionality
- [x] Toggle only appears when Inactive Branch Detection is enabled
- [x] Inactive PRs are filtered from all sections (authored, review, other)
- [x] Warning icon and repo indicators exclude hidden inactive PRs
- [x] Available repositories list still shows all repos (including ones with only inactive PRs)